### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: New Release
 
+permissions:
+  contents: write
+
 on:
   milestone:
     types: [closed]


### PR DESCRIPTION
Potential fix for [https://github.com/mod-posh/yaml2doc/security/code-scanning/6](https://github.com/mod-posh/yaml2doc/security/code-scanning/6)

To fix the problem, add an explicit `permissions` block with the minimum required privileges to either the workflow root (before `jobs:`), or to the `create-release` job itself, if only that job is present. Since this workflow performs actions such as pushing commits, creating releases, and interacting with repository contents, you should grant `contents: write` and possibly `pull-requests: write` (if relevant—though in this workflow only releases and contents are clearly required), as well as restrict other permissions to `read` where needed. As a best practice starting point, set `contents: write` at a minimum at the workflow level or job level, and further restrict if more granularity is possible. Edit `.github/workflows/release.yml` to insert this block after the `name:` line and before `jobs:`, or as a child of the relevant job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
