### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Merge Test Workflow
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/mod-posh/yaml2doc/security/code-scanning/5](https://github.com/mod-posh/yaml2doc/security/code-scanning/5)

To fix this issue, we should add a `permissions` block at the minimal required level for the workflow—the root level, so all jobs inherit it—limiting the permissions of the `GITHUB_TOKEN`. The minimal permissions required for this workflow are `contents: read`, so set:
```yaml
permissions:
  contents: read
```
directly below the workflow name (line 1), before the `on:` block, in the `.github/workflows/test.yml` file. This change reduces privileges according to the principle of least privilege, and meets static analysis requirements. No further changes are needed for jobs or steps; no new method definitions or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
