### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -1,4 +1,6 @@
 name: Announce New Release
+permissions:
+  contents: read
 
 on:
   workflow_run:


### PR DESCRIPTION
Potential fix for [https://github.com/mod-posh/yaml2doc/security/code-scanning/3](https://github.com/mod-posh/yaml2doc/security/code-scanning/3)

The fix is to add an explicit `permissions` block to the workflow, restricting its access to the repository. The principle of least privilege should be used. In this case, the workflow checks out the code (so `contents: read` is likely needed), uses external services (Bluesky, Discord) authenticated via secrets (not requiring any repo write access), and reads the latest release via the `gh release list` command (which also only needs read access). Therefore, the workflow only requires `contents: read` access. The ideal place for the `permissions` block is at the workflow's root level (top-level, before `jobs:`), so it applies to the entire workflow. This keeps the workflow secure and maintainable.

This means adding:

```yaml
permissions:
  contents: read
```
immediately after the `name:` (line 1) and before the `on:` block (line 3).

No other file or region changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
